### PR TITLE
Updating phpstan to 2.0

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local pipeline(name, phpversion, params) = {
                 depends: [ "composer" ],
                 failure: "ignore",
                 commands: [
-                    "vendor/bin/phpstan analyse src",
+                    "./vendor/bin/phpstan",
                 ]
             },
             {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -103,4 +103,6 @@ local pipeline(name, phpversion, params) = {
     pipeline("8.1 lowest", "8.1", "--prefer-stable --prefer-lowest"),
     pipeline("8.1", "8.1", "--prefer-stable"),
     pipeline("8.2", "8.2", "--prefer-stable"),
+    pipeline("8.3", "8.3", "--prefer-stable"),
+    pipeline("8.4", "8.4", "--prefer-stable"),
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   image: joomlaprojects/docker-images:php8.1-ast
   name: phan
 - commands:
-  - vendor/bin/phpstan analyse src
+  - ./vendor/bin/phpstan
   depends:
   - composer
   failure: ignore

--- a/.drone.yml
+++ b/.drone.yml
@@ -109,7 +109,48 @@ volumes:
     path: /tmp/composer-cache
   name: composer-cache
 ---
+kind: pipeline
+name: PHP 8.3
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.3
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  failure: ignore
+  image: joomlaprojects/docker-images:php8.3
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
+kind: pipeline
+name: PHP 8.4
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.4
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  image: joomlaprojects/docker-images:php8.4
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
 kind: signature
-hmac: 59cf4330ff357ca38aca1af662d3aa88a67a14983f0a767b8f87c4621eb022fb
+hmac: 26e7d9485c196beec549b0cf9aff0858ffb8af222de3ec1a82e8ba323e677a2f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,6 +110,6 @@ volumes:
   name: composer-cache
 ---
 kind: signature
-hmac: 318daf24591809e75fb83d8963b8c21d6872a391d2310cf77f1113273ffab004
+hmac: 59cf4330ff357ca38aca1af662d3aa88a67a14983f0a767b8f87c4621eb022fb
 
 ...

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "phpunit/phpunit": "^9.5.28",
         "symfony/web-link": "^5.0",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "phpstan/phpstan": "^1.10.7",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phan/phan": "^5.4.2"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+
+includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+	level: 5
+	phpVersion: 80100
+	reportUnmatchedIgnoredErrors: false
+	paths:
+		- src


### PR DESCRIPTION
### Summary of Changes
This updates phpstan to version 2.0, adds a configuration file for phpstan and sets the level to 5, adds the deprecation plugin to it and changes the call in drone.

### Testing Instructions
Codereview
